### PR TITLE
correzione del branch su cui scatenare gli eventi nel worflow

### DIFF
--- a/.github/workflows/test_automatization.yml
+++ b/.github/workflows/test_automatization.yml
@@ -2,10 +2,10 @@ name: test_automatization
 on: 
   push:
     branches:
-     - master
+     - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nel workflow test_automatization era presente un nome del branch in cui scatenare gli eventi sbagliato.

In questa PR ho cambiato tale nome del branch passando da master a main 